### PR TITLE
Change hmset to hset because of a deprecated warning

### DIFF
--- a/database-caching/example.py
+++ b/database-caching/example.py
@@ -66,7 +66,7 @@ def planet(id):
     res = Database.record(sql, (id,))
 
     if res:
-        Cache.hmset(key, res)
+        Cache.hset(key, mapping=res)
         Cache.expire(key, TTL)
 
     return res


### PR DESCRIPTION
*Description of changes:*

When I using  this sample code, I got an error `DeprecationWarning: Redis.hmset() is deprecated. Use Redis.hset() instead`