### PR TITLE
Add ElastiCache for Valkey Terraform Implementation with Documentation

### DIFF
--- a/blogs/elasticache-valkey/terraform/.gitignore
+++ b/blogs/elasticache-valkey/terraform/.gitignore
@@ -1,0 +1,29 @@
+# Local .terraform directories
+**/.terraform/*
+.terraform.lock.hcl
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+*.tfvars
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*

--- a/blogs/elasticache-valkey/terraform/README.md
+++ b/blogs/elasticache-valkey/terraform/README.md
@@ -1,0 +1,175 @@
+# Amazon ElastiCache for Valkey - Terraform Deployment
+
+This repository contains Terraform code for deploying Amazon ElastiCache for Valkey in two different deployment models:
+
+1. **Node-based deployment** - Traditional ElastiCache deployment with specified node types and cluster configuration
+2. **Serverless deployment** - Fully managed serverless ElastiCache deployment with automatic scaling
+
+## Repository Structure
+
+```
+terraform/
+├── network/                # Shared network module for VPC and subnet configuration
+├── node-based/            # Node-based ElastiCache for Valkey deployment
+├── serverless/            # Serverless ElastiCache for Valkey deployment
+└── README.md              # This file
+```
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) (v1.0.0 or newer)
+- AWS account with appropriate permissions
+- AWS CLI configured with access credentials
+
+## Deployment Options
+
+### 1. Node-Based Deployment
+
+The node-based deployment creates an ElastiCache for Valkey cluster with specified node types, sharding, and replication configuration. This deployment model gives you fine-grained control over the cluster's resources and configuration.
+
+**Key Features:**
+- Configurable node type and count
+- Multi-AZ deployment with automatic failover
+- Sharding with configurable node groups
+- Transit encryption with KMS
+- Authentication with AWS Secrets Manager
+- CloudWatch Logs integration for slow logs and engine logs
+
+**Default Configuration:**
+- Node Type: `cache.t2.small`
+- Engine Version: `8.0`
+- Node Groups (Shards): 3
+- Replicas per Node Group: 2
+
+### 2. Serverless Deployment
+
+The serverless deployment creates an ElastiCache for Valkey serverless cache that automatically scales based on your workload. This deployment model is ideal for applications with variable or unpredictable workloads.
+
+**Key Features:**
+- Fully managed serverless deployment
+- Automatic scaling based on workload
+- Configurable data storage and ECPU limits
+- Daily snapshots with configurable retention
+- KMS encryption for data at rest
+
+**Default Configuration:**
+- Data Storage Limit: 10 GB
+- ECPU per Second: 5000
+- Major Engine Version: 7
+- Snapshot Retention: 1 day
+
+## Deployment Instructions
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/aws-samples/amazon-elasticache-samples.git
+cd amazon-elasticache-samples/blogs/elasticache-valkey/terraform
+```
+
+### 2. Choose Deployment Model
+
+Navigate to either the `node-based` or `serverless` directory:
+
+```bash
+cd node-based
+# OR
+cd serverless
+```
+
+### 3. Configure Variables
+
+Review and modify the `variables.tf` file to customize your deployment. You can also create a `terraform.tfvars` file to set variable values:
+
+```hcl
+# Example terraform.tfvars
+region     = "us-east-1"
+access_key = "your-access-key"
+secret_key = "your-secret-key"
+name       = "my-valkey-cache"
+```
+
+### 4. Initialize Terraform
+
+```bash
+terraform init
+```
+
+### 5. Plan the Deployment
+
+```bash
+terraform plan
+```
+
+### 6. Apply the Configuration
+
+```bash
+terraform apply
+```
+
+### 7. Clean Up Resources
+
+When you're done, you can destroy all created resources:
+
+```bash
+terraform destroy
+```
+
+## Configuration Variables
+
+### Common Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `region` | AWS region to deploy resources | `us-east-2` |
+| `access_key` | AWS access key | `""` |
+| `secret_key` | AWS secret key | `""` |
+| `name` | Name prefix for resources | Varies by deployment |
+| `vpc_cidr` | CIDR block for the VPC | Varies by deployment |
+| `subnet_cidr_private` | CIDR blocks for private subnets | Varies by deployment |
+
+### Node-Based Specific Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `node_type` | ElastiCache node type | `cache.t2.small` |
+| `engine_version` | Valkey engine version | `8.0` |
+| `port` | Port for ElastiCache connections | `6379` |
+| `num_node_groups` | Number of shards | `3` |
+| `replicas_per_node_group` | Number of replicas per shard | `2` |
+| `parameter_group_name` | Parameter group name | `default.valkey8.cluster.on` |
+
+### Serverless Specific Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `data_storage` | Maximum data storage in GB | `10` |
+| `ecpu_per_second` | Maximum ECPUs per second | `5000` |
+| `daily_snapshot_time` | Time for daily snapshots | `09:00` |
+| `major_engine_version` | Valkey major engine version | `7` |
+| `snapshot_retention_limit` | Number of days to retain snapshots | `1` |
+
+## Security Features
+
+Both deployment models include several security features:
+
+1. **Encryption at Rest**: All data is encrypted using AWS KMS
+2. **Network Security**: Deployed within private subnets with security groups
+3. **Authentication**: Node-based deployment includes authentication token stored in AWS Secrets Manager
+4. **Transit Encryption**: Node-based deployment enables TLS for data in transit
+
+## Logging and Monitoring
+
+The node-based deployment includes CloudWatch Logs integration for:
+- Slow logs: Captures slow operations for performance analysis
+- Engine logs: Captures engine-level events for troubleshooting
+
+## Additional Resources
+
+- [Amazon ElastiCache Documentation](https://docs.aws.amazon.com/elasticache/)
+- [What is Valkey?](https://aws.amazon.com/elasticache/what-is-valkey/)
+- [Terraform AWS Provider Documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
+
+## License
+
+This sample code is made available under the MIT-0 license. See the LICENSE file.

--- a/blogs/elasticache-valkey/terraform/README.md
+++ b/blogs/elasticache-valkey/terraform/README.md
@@ -107,7 +107,23 @@ terraform plan
 terraform apply
 ```
 
-### 7. Clean Up Resources
+### 7. Expected Deployment Results
+
+After running `terraform apply`, you should see output messages indicating successful resource creation. The deployment time varies between the two deployment models:
+
+**Node-based deployment** (typically takes 8-10 minutes):
+```
+aws_elasticache_replication_group.node_based: Creation complete after 9m29s [id=elasticache-valkey-node-based-demo]
+```
+
+**Serverless deployment** (typically takes 2-3 minutes):
+```
+aws_elasticache_serverless_cache.serverless_cache: Creation complete after 2m17s [id=elasticache-valkey-serverless-demo]
+```
+
+Once deployment is complete, you can access your ElastiCache for Valkey instance using the connection information available in the AWS Management Console or through AWS CLI commands.
+
+### 8. Clean Up Resources
 
 When you're done, you can destroy all created resources:
 

--- a/blogs/elasticache-valkey/terraform/network/network.tf
+++ b/blogs/elasticache-valkey/terraform/network/network.tf
@@ -21,3 +21,9 @@ resource "aws_route_table" "private" {
   vpc_id = aws_vpc.this.id
   tags   = merge(var.tags, { "Name" = "${var.vpc_name}-private-${count.index + 1}" })
 }
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association
+resource "aws_route_table_association" "private" {
+  count          = length(var.subnet_cidr_private) > 0 ? length(var.subnet_cidr_private) : 0
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = aws_route_table.private[count.index].id
+}

--- a/blogs/elasticache-valkey/terraform/network/network.tf
+++ b/blogs/elasticache-valkey/terraform/network/network.tf
@@ -1,0 +1,23 @@
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc
+resource "aws_vpc" "this" {
+  cidr_block = var.vpc_cidr
+  tags       = merge(var.tags, { "Name" = var.vpc_name })
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet
+resource "aws_subnet" "private" {
+  count             = length(var.subnet_cidr_private)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.subnet_cidr_private[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index % 3]
+  tags              = merge(var.tags, { "Name" = "${var.vpc_name}-private-${count.index + 1}" })
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table
+resource "aws_route_table" "private" {
+  count  = length(var.subnet_cidr_private) > 0 ? length(var.subnet_cidr_private) : 0
+  vpc_id = aws_vpc.this.id
+  tags   = merge(var.tags, { "Name" = "${var.vpc_name}-private-${count.index + 1}" })
+}

--- a/blogs/elasticache-valkey/terraform/network/output.tf
+++ b/blogs/elasticache-valkey/terraform/network/output.tf
@@ -1,0 +1,15 @@
+# VPC
+output "vpc" {
+  description = "The VPC created via this module."
+  value       = aws_vpc.this
+}
+# Private Subnets
+output "private_subnets" {
+  description = "List of private subnets."
+  value       = aws_subnet.private[*]
+}
+# Security Group id
+output "security_group" {
+  description = "The ID of the security group."
+  value       = aws_security_group.custom_sg
+}

--- a/blogs/elasticache-valkey/terraform/network/provider.tf
+++ b/blogs/elasticache-valkey/terraform/network/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/blogs/elasticache-valkey/terraform/network/security_group.tf
+++ b/blogs/elasticache-valkey/terraform/network/security_group.tf
@@ -1,0 +1,36 @@
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(var.tags, { "Name" = "${var.vpc_name}-default" })
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
+resource "aws_security_group" "custom_sg" {
+  name        = "${var.vpc_name}_allow_inbound_access"
+  description = "manage traffic for ${var.vpc_name}"
+  vpc_id      = aws_vpc.this.id
+  tags = {
+    "Name" = "${var.vpc_name}-sg"
+  }
+  #checkov:skip=CKV2_AWS_5: "Ensure that Security Groups are attached to another resource"
+  #This security group is attached to the Amazon ElastiCache Serverless resource
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule
+resource "aws_security_group_rule" "ingress_custom_sg" {
+  description       = "allow traffic to the cache cluster"
+  type              = "ingress"
+  from_port         = 6379
+  to_port           = 6379
+  protocol          = "tcp"
+  cidr_blocks       = [var.vpc_cidr]
+  security_group_id = aws_security_group.custom_sg.id
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule
+resource "aws_security_group_rule" "egress_custom_sg" {
+  description       = "allow traffic to reach outside the vpc"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = [var.vpc_cidr]
+  security_group_id = aws_security_group.custom_sg.id
+}

--- a/blogs/elasticache-valkey/terraform/network/variables.tf
+++ b/blogs/elasticache-valkey/terraform/network/variables.tf
@@ -1,0 +1,55 @@
+variable "region" {
+  description = "The AWS region to provision resources."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]{1}$", var.region))
+    error_message = "Region must be a valid AWS region name (e.g., us-east-1, eu-west-1)."
+  }
+}
+variable "vpc_name" {
+  description = "Name of the VPC."
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]*$", var.vpc_name))
+    error_message = "VPC name can only contain alphanumeric characters, hyphens, and underscores."
+  }
+
+  validation {
+    condition     = length(var.vpc_name) <= 255
+    error_message = "VPC name cannot be longer than 255 characters."
+  }
+}
+variable "vpc_cidr" {
+  type        = string
+  description = "The CIDR block for the VPC"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "VPC CIDR must be a valid IPv4 CIDR block."
+  }
+
+  validation {
+    condition     = tonumber(split("/", var.vpc_cidr)[1]) >= 16 && tonumber(split("/", var.vpc_cidr)[1]) <= 28
+    error_message = "VPC CIDR block must be between /16 and /28."
+  }
+}
+variable "subnet_cidr_private" {
+  description = "CIDR blocks for the private subnets."
+  default     = []
+  type        = list(any)
+
+  validation {
+    condition = alltrue([
+      for cidr in var.subnet_cidr_private : can(cidrhost(cidr, 0))
+    ])
+    error_message = "All private subnet CIDR blocks must be valid IPv4 CIDR notation."
+  }
+}
+variable "tags" {
+  description = "AWS Cloud resource tags."
+  type        = map(string)
+  default = {
+    "Source" = "https://github.com/aws-samples/amazon-elasticache-samples/tree/main/blogs"
+  }
+}

--- a/blogs/elasticache-valkey/terraform/node-based/auth.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/auth.tf
@@ -1,0 +1,74 @@
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
+resource "aws_kms_key" "encrypt_secret" {
+  enable_key_rotation     = true
+  description             = "Key to encrypt secret for ${var.name}."
+  deletion_window_in_days = 7
+  tags = {
+    Name = "${var.name}-encrypt-secret"
+  }
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
+resource "aws_kms_alias" "encrypt_secret" {
+  name          = "alias/${var.name}-encrypt-secret"
+  target_key_id = aws_kms_key.encrypt_secret.key_id
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy
+resource "aws_kms_key_policy" "encrypt_secret_policy" {
+  key_id = aws_kms_key.encrypt_secret.id
+  policy = jsonencode({
+    Id      = "${var.name}-encrypt-secret"
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow access through AWS Secrets Manager for all principals in the account that are authorized to use AWS Secrets Manager"
+        Effect = "Allow"
+        Principal = {
+          AWS = ["*"]
+        }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey*"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:CallerAccount" = "${data.aws_caller_identity.current.account_id}"
+            "kms:ViaService"    = "secretsmanager.${var.region}.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+#https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html#auth-overview
+#https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password
+resource "random_password" "auth" {
+  length           = 128
+  special          = true
+  override_special = "!&#$^<>-"
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret
+resource "aws_secretsmanager_secret" "elasticache_auth" {
+  name                    = var.name
+  recovery_window_in_days = 0
+  kms_key_id              = aws_kms_key.encrypt_secret.id
+  #checkov:skip=CKV2_AWS_57: Disabled Secrets Manager secrets automatic rotation
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version
+resource "aws_secretsmanager_secret_version" "auth" {
+  secret_id     = aws_secretsmanager_secret.elasticache_auth.id
+  secret_string = random_password.auth.result
+}

--- a/blogs/elasticache-valkey/terraform/node-based/elasticache_node_based.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/elasticache_node_based.tf
@@ -1,0 +1,41 @@
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group
+resource "aws_elasticache_subnet_group" "elasticache_subnet" {
+  name       = "${var.name}-cache-subnet"
+  subnet_ids = [for subnet in module.vpc.private_subnets : subnet.id]
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group
+resource "aws_elasticache_replication_group" "node_based" {
+  automatic_failover_enabled = true
+  subnet_group_name          = aws_elasticache_subnet_group.elasticache_subnet.name
+  replication_group_id       = var.name
+  description                = "ElastiCache cluster for ${var.name}"
+  node_type                  = var.node_type
+  engine                     = "valkey"
+  engine_version             = var.engine_version
+  parameter_group_name       = var.parameter_group_name
+  port                       = var.port
+  multi_az_enabled           = true
+  num_node_groups            = var.num_node_groups
+  replicas_per_node_group    = var.replicas_per_node_group
+  at_rest_encryption_enabled = true
+  kms_key_id                 = aws_kms_key.encrypt_cache.id
+  transit_encryption_enabled = true
+  auth_token                 = aws_secretsmanager_secret_version.auth.secret_string
+  security_group_ids         = [module.vpc.security_group.id]
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.slow_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+  }
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.engine_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "engine-log"
+  }
+  lifecycle {
+    ignore_changes = [kms_key_id]
+  }
+  apply_immediately = true
+}

--- a/blogs/elasticache-valkey/terraform/node-based/kms.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/kms.tf
@@ -1,0 +1,54 @@
+data "aws_caller_identity" "current" {}
+locals {
+  principal_root_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
+resource "aws_kms_key" "encrypt_cache" {
+  description             = "KMS key to encrypt cache for ${var.name}"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
+resource "aws_kms_alias" "key" {
+  name          = "alias/cache-${var.name}"
+  target_key_id = aws_kms_key.encrypt_cache.id
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy
+resource "aws_kms_key_policy" "encrypt_policy" {
+  key_id = aws_kms_key.encrypt_cache.id
+  policy = jsonencode({
+    Id = "encrypt-node-based-cache"
+    Statement = [
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "${local.principal_root_arn}"
+        }
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+      {
+        Sid    = "Allow ElastiCache Service"
+        Effect = "Allow"
+        Principal = {
+          Service = "elasticache.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:CreateGrant",
+          "kms:ReEncrypt*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "elasticache.${var.region}.amazonaws.com"
+          }
+        }
+      }
+    ]
+    Version = "2012-10-17"
+  })
+}

--- a/blogs/elasticache-valkey/terraform/node-based/kms.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/kms.tf
@@ -10,14 +10,14 @@ resource "aws_kms_key" "encrypt_cache" {
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
 resource "aws_kms_alias" "key" {
-  name          = "alias/cache-${var.name}"
+  name          = "alias/${var.name}-encrypt-cache"
   target_key_id = aws_kms_key.encrypt_cache.id
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy
 resource "aws_kms_key_policy" "encrypt_policy" {
   key_id = aws_kms_key.encrypt_cache.id
   policy = jsonencode({
-    Id = "encrypt-node-based-cache"
+    Id = "${var.name}-encrypt-cache"
     Statement = [
       {
         Action = "kms:*"

--- a/blogs/elasticache-valkey/terraform/node-based/logs.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/logs.tf
@@ -1,0 +1,85 @@
+locals {
+  principal_logs_arn = "logs.${var.region}.amazonaws.com"
+  slow_log_arn       = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/elasticache/${var.name}/slow-log"
+  engine_log_arn     = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:/elasticache/${var.name}/engine-log"
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
+resource "aws_kms_key" "encrypt_logs" {
+  enable_key_rotation     = true
+  description             = "Key to encrypt logs for ${var.name}."
+  deletion_window_in_days = 7
+  tags = {
+    Name = "${var.name}-encrypt-logs"
+  }
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
+resource "aws_kms_alias" "encrypt_logs" {
+  name          = "alias/${var.name}-encrypt-logs"
+  target_key_id = aws_kms_key.encrypt_logs.key_id
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy
+resource "aws_kms_key_policy" "encrypt_logs_policy" {
+  key_id = aws_kms_key.encrypt_logs.id
+  policy = jsonencode({
+    Id = "${var.name}-encrypt-logs"
+    Statement = [
+      {
+        Action = ["kms:*"]
+        Effect = "Allow"
+        Principal = {
+          AWS = "${local.principal_root_arn}"
+        }
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+      {
+        Sid    = "Allow ElastiCache to use the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "elasticache.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:ReEncrypt*",
+          "kms:CreateGrant",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect : "Allow",
+        Principal : {
+          Service : "${local.principal_logs_arn}"
+        },
+        Action : [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ],
+        Resource : "*",
+        Condition : {
+          ArnEquals : {
+            "kms:EncryptionContext:aws:logs:arn" : [local.slow_log_arn, local.engine_log_arn]
+          }
+        }
+      }
+    ]
+    Version = "2012-10-17"
+  })
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group
+resource "aws_cloudwatch_log_group" "slow_log" {
+  name              = "/elasticache/${var.name}/slow-log"
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.encrypt_logs.arn
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group
+resource "aws_cloudwatch_log_group" "engine_log" {
+  name              = "/elasticache/${var.name}/engine-log"
+  retention_in_days = 365
+  kms_key_id        = aws_kms_key.encrypt_logs.arn
+}

--- a/blogs/elasticache-valkey/terraform/node-based/network.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/network.tf
@@ -1,0 +1,7 @@
+module "vpc" {
+  source              = "../network"
+  vpc_name            = var.name
+  region              = var.region
+  vpc_cidr            = var.vpc_cidr
+  subnet_cidr_private = var.subnet_cidr_private
+}

--- a/blogs/elasticache-valkey/terraform/node-based/provider.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/provider.tf
@@ -4,7 +4,7 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.95.0"
     }
-        random = {
+    random = {
       source  = "hashicorp/random"
       version = "3.6.3"
     }

--- a/blogs/elasticache-valkey/terraform/node-based/provider.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/provider.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.95.0"
+    }
+        random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+
+provider "aws" {
+  region     = var.region
+  access_key = var.access_key
+  secret_key = var.secret_key
+  default_tags {
+    tags = {
+      Source = "https://github.com/aws-samples/amazon-elasticache-samples/tree/main/blogs"
+      Type   = "elasticache-valkey-node-based"
+    }
+  }
+}
+provider "random" {
+  # Configuration options
+}

--- a/blogs/elasticache-valkey/terraform/node-based/variables.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/variables.tf
@@ -1,0 +1,35 @@
+#Define AWS Region
+variable "region" {
+  description = "Infrastructure region"
+  type        = string
+  default     = "us-east-2"
+}
+#Define IAM User Access Key
+variable "access_key" {
+  description = "The access_key that belongs to the IAM user"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+#Define IAM User Secret Key
+variable "secret_key" {
+  description = "The secret_key that belongs to the IAM user"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "name" {
+  description = "The name of the application."
+  type        = string
+  default     = "elasticache-valkey-node-based-demo"
+}
+variable "vpc_cidr" {
+  description = "The CIDR of the VPC."
+  type        = string
+  default     = "12.25.25.0/25"
+}
+variable "subnet_cidr_private" {
+  description = "The CIDR blocks for the public subnets."
+  type        = list(any)
+  default     = ["12.25.25.0/27", "12.25.25.32/27"]
+}

--- a/blogs/elasticache-valkey/terraform/node-based/variables.tf
+++ b/blogs/elasticache-valkey/terraform/node-based/variables.tf
@@ -33,3 +33,33 @@ variable "subnet_cidr_private" {
   type        = list(any)
   default     = ["12.25.25.0/27", "12.25.25.32/27"]
 }
+variable "node_type" {
+  description = "Instance class to be used."
+  type        = string
+  default     = "cache.t2.small"
+}
+variable "engine_version" {
+  description = "Version number of the cache engine to be used for the cache clusters in this replication group."
+  type        = string
+  default     = "8.0"
+}
+variable "port" {
+  description = "Port number on which each of the cache nodes will accept connections."
+  type        = number
+  default     = 6379
+}
+variable "num_node_groups" {
+  description = "Number of node groups (shards) for the replication group. Changing this number will trigger a resizing operation before other settings modifications"
+  type        = number
+  default     = 3
+}
+variable "replicas_per_node_group" {
+  description = "Number of replica nodes in each node group."
+  type        = number
+  default     = 2
+}
+variable "parameter_group_name" {
+  description = "Name of the parameter group to associate with this replication group."
+  type        = string
+  default     = "default.valkey8.cluster.on"
+}

--- a/blogs/elasticache-valkey/terraform/serverless/elasticache_serverless.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/elasticache_serverless.tf
@@ -12,7 +12,7 @@ resource "aws_elasticache_serverless_cache" "serverless_cache" {
     }
   }
   daily_snapshot_time      = var.daily_snapshot_time
-  description              = "Valkey cache server for ${var.name}"
+  description              = "ElastiCache cluster for ${var.name}"
   major_engine_version     = var.major_engine_version
   snapshot_retention_limit = var.snapshot_retention_limit
   security_group_ids       = [module.vpc.security_group.id]

--- a/blogs/elasticache-valkey/terraform/serverless/elasticache_serverless.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/elasticache_serverless.tf
@@ -4,17 +4,17 @@ resource "aws_elasticache_serverless_cache" "serverless_cache" {
   name   = var.name
   cache_usage_limits {
     data_storage {
-      maximum = 10
+      maximum = var.data_storage
       unit    = "GB"
     }
     ecpu_per_second {
-      maximum = 5000
+      maximum = var.ecpu_per_second
     }
   }
-  daily_snapshot_time      = "09:00"
+  daily_snapshot_time      = var.daily_snapshot_time
   description              = "Valkey cache server for ${var.name}"
-  major_engine_version     = "7"
-  snapshot_retention_limit = 1
+  major_engine_version     = var.major_engine_version
+  snapshot_retention_limit = var.snapshot_retention_limit
   security_group_ids       = [module.vpc.security_group.id]
   subnet_ids               = module.vpc.private_subnets.*.id
   kms_key_id               = aws_kms_key.custom_kms_key.arn

--- a/blogs/elasticache-valkey/terraform/serverless/elasticache_serverless.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/elasticache_serverless.tf
@@ -1,0 +1,21 @@
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_serverless_cache
+resource "aws_elasticache_serverless_cache" "serverless_cache" {
+  engine = "valkey"
+  name   = var.name
+  cache_usage_limits {
+    data_storage {
+      maximum = 10
+      unit    = "GB"
+    }
+    ecpu_per_second {
+      maximum = 5000
+    }
+  }
+  daily_snapshot_time      = "09:00"
+  description              = "Valkey cache server for ${var.name}"
+  major_engine_version     = "7"
+  snapshot_retention_limit = 1
+  security_group_ids       = [module.vpc.security_group.id]
+  subnet_ids               = module.vpc.private_subnets.*.id
+  kms_key_id               = aws_kms_key.custom_kms_key.arn
+}

--- a/blogs/elasticache-valkey/terraform/serverless/elasticache_serverless.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/elasticache_serverless.tf
@@ -17,5 +17,5 @@ resource "aws_elasticache_serverless_cache" "serverless_cache" {
   snapshot_retention_limit = var.snapshot_retention_limit
   security_group_ids       = [module.vpc.security_group.id]
   subnet_ids               = module.vpc.private_subnets.*.id
-  kms_key_id               = aws_kms_key.custom_kms_key.arn
+  kms_key_id               = aws_kms_key.encrypt_cache.arn
 }

--- a/blogs/elasticache-valkey/terraform/serverless/kms.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/kms.tf
@@ -17,7 +17,7 @@ resource "aws_kms_alias" "key" {
 resource "aws_kms_key_policy" "encrypt_policy" {
   key_id = aws_kms_key.encrypt_cache.id
   policy = jsonencode({
-    Id = "encrypt-serverless-cache"
+    Id = "${var.name}-encrypt-cache"
     Statement = [
       {
         Action = "kms:*"

--- a/blogs/elasticache-valkey/terraform/serverless/kms.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/kms.tf
@@ -1,0 +1,54 @@
+data "aws_caller_identity" "current" {}
+locals {
+  principal_root_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
+resource "aws_kms_key" "custom_kms_key" {
+  description             = "KMS key for ${var.name}"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
+resource "aws_kms_alias" "key" {
+  name          = "alias/${var.name}"
+  target_key_id = aws_kms_key.custom_kms_key.id
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy
+resource "aws_kms_key_policy" "encrypt_app" {
+  key_id = aws_kms_key.custom_kms_key.id
+  policy = jsonencode({
+    Id = "encryption-rest"
+    Statement = [
+      {
+        Action = "kms:*"
+        Effect = "Allow"
+        Principal = {
+          AWS = "${local.principal_root_arn}"
+        }
+        Resource = "*"
+        Sid      = "Enable IAM User Permissions"
+      },
+      {
+        Sid    = "Allow ElastiCache Service"
+        Effect = "Allow"
+        Principal = {
+          Service = "elasticache.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:CreateGrant",
+          "kms:ReEncrypt*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "elasticache.${var.region}.amazonaws.com"
+          }
+        }
+      }
+    ]
+    Version = "2012-10-17"
+  })
+}

--- a/blogs/elasticache-valkey/terraform/serverless/kms.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/kms.tf
@@ -3,7 +3,7 @@ locals {
   principal_root_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
-resource "aws_kms_key" "custom_kms_key" {
+resource "aws_kms_key" "encrypt_cache" {
   description             = "KMS key for ${var.name}"
   deletion_window_in_days = 7
   enable_key_rotation     = true
@@ -11,11 +11,11 @@ resource "aws_kms_key" "custom_kms_key" {
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
 resource "aws_kms_alias" "key" {
   name          = "alias/${var.name}"
-  target_key_id = aws_kms_key.custom_kms_key.id
+  target_key_id = aws_kms_key.encrypt_cache.id
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy
 resource "aws_kms_key_policy" "encrypt_app" {
-  key_id = aws_kms_key.custom_kms_key.id
+  key_id = aws_kms_key.encrypt_cache.id
   policy = jsonencode({
     Id = "encryption-rest"
     Statement = [

--- a/blogs/elasticache-valkey/terraform/serverless/kms.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/kms.tf
@@ -4,20 +4,20 @@ locals {
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
 resource "aws_kms_key" "encrypt_cache" {
-  description             = "KMS key for ${var.name}"
+  description             = "KMS key to encrypt cache for ${var.name}"
   deletion_window_in_days = 7
   enable_key_rotation     = true
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
 resource "aws_kms_alias" "key" {
-  name          = "alias/${var.name}"
+  name          = "alias/cache-${var.name}"
   target_key_id = aws_kms_key.encrypt_cache.id
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy
-resource "aws_kms_key_policy" "encrypt_app" {
+resource "aws_kms_key_policy" "encrypt_policy" {
   key_id = aws_kms_key.encrypt_cache.id
   policy = jsonencode({
-    Id = "encryption-rest"
+    Id = "encrypt-serverless-cache"
     Statement = [
       {
         Action = "kms:*"

--- a/blogs/elasticache-valkey/terraform/serverless/kms.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/kms.tf
@@ -10,7 +10,7 @@ resource "aws_kms_key" "encrypt_cache" {
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias
 resource "aws_kms_alias" "key" {
-  name          = "alias/cache-${var.name}"
+  name          = "alias/${var.name}-encrypt-cache"
   target_key_id = aws_kms_key.encrypt_cache.id
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy

--- a/blogs/elasticache-valkey/terraform/serverless/network.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/network.tf
@@ -1,0 +1,7 @@
+module "vpc" {
+  source              = "../network"
+  vpc_name            = var.name
+  region              = var.region
+  vpc_cidr            = var.vpc_cidr
+  subnet_cidr_private = var.subnet_cidr_private
+}

--- a/blogs/elasticache-valkey/terraform/serverless/provider.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/provider.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.95.0"
+    }
+  }
+}
+
+provider "aws" {
+  region     = var.region
+  access_key = var.access_key
+  secret_key = var.secret_key
+  default_tags {
+    tags = {
+      Source = "https://github.com/aws-samples/amazon-elasticache-samples/tree/main/blogs"
+      Type   = "elasticache-valkey-serverless"
+    }
+  }
+}

--- a/blogs/elasticache-valkey/terraform/serverless/variables.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/variables.tf
@@ -1,0 +1,35 @@
+#Define AWS Region
+variable "region" {
+  description = "Infrastructure region"
+  type        = string
+  default     = "us-east-2"
+}
+#Define IAM User Access Key
+variable "access_key" {
+  description = "The access_key that belongs to the IAM user"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+#Define IAM User Secret Key
+variable "secret_key" {
+  description = "The secret_key that belongs to the IAM user"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "name" {
+  description = "The name of the application."
+  type        = string
+  default     = "elasticache-valkey-serverless-demo"
+}
+variable "vpc_cidr" {
+  description = "The CIDR of the VPC."
+  type        = string
+  default     = "12.25.15.0/25"
+}
+variable "subnet_cidr_private" {
+  description = "The CIDR blocks for the public subnets."
+  type        = list(any)
+  default     = ["12.25.15.0/27", "12.25.15.32/27"]
+}

--- a/blogs/elasticache-valkey/terraform/serverless/variables.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/variables.tf
@@ -51,7 +51,7 @@ variable "daily_snapshot_time" {
 variable "major_engine_version" {
   description = "The version of the cache engine that will be used to create the serverless cache."
   type        = string
-  default     = "7"
+  default     = "8"
 }
 variable "snapshot_retention_limit" {
   description = "The number of snapshots that will be retained for the serverless cache that is being created."

--- a/blogs/elasticache-valkey/terraform/serverless/variables.tf
+++ b/blogs/elasticache-valkey/terraform/serverless/variables.tf
@@ -33,3 +33,28 @@ variable "subnet_cidr_private" {
   type        = list(any)
   default     = ["12.25.15.0/27", "12.25.15.32/27"]
 }
+variable "data_storage" {
+  description = "The maximum data storage limit in the cache, expressed in Gigabytes."
+  type        = number
+  default     = 10
+}
+variable "ecpu_per_second" {
+  description = "The configuration for the number of ElastiCache Processing Units (ECPU) the cache can consume per second."
+  type        = number
+  default     = 5000
+}
+variable "daily_snapshot_time" {
+  description = "The daily time that snapshots will be created from the new serverless cache."
+  type        = string
+  default     = "09:00"
+}
+variable "major_engine_version" {
+  description = "The version of the cache engine that will be used to create the serverless cache."
+  type        = string
+  default     = "7"
+}
+variable "snapshot_retention_limit" {
+  description = "The number of snapshots that will be retained for the serverless cache that is being created."
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
## Description
This PR adds a complete Terraform implementation for deploying Amazon ElastiCache for Valkey in two deployment models: node-based and serverless. The code includes all necessary resources for both deployment options along with comprehensive documentation.

## Changes
- Added Terraform code for node-based ElastiCache for Valkey deployment
- Added Terraform code for serverless ElastiCache for Valkey deployment
- Created shared network module for VPC and subnet configuration
- Implemented security features including KMS encryption, authentication, and network security
- Added logging configuration for node-based deployment
- Created comprehensive README with detailed documentation

## Implementation Details
- **Network Module**: Configures VPC, subnets, and security groups
- **Node-based Deployment**: Implements traditional ElastiCache with configurable node types, sharding, and replication
- **Serverless Deployment**: Implements fully managed serverless ElastiCache with automatic scaling
- **Security**: Includes KMS encryption, authentication via Secrets Manager, and proper network isolation

## Benefits
This implementation provides users with ready-to-deploy Terraform code for both ElastiCache for Valkey deployment models, allowing them to choose the approach that best fits their use case. The comprehensive documentation helps users understand, configure, and deploy the infrastructure efficiently.

## Testing
The Terraform code has been tested in multiple AWS regions to ensure proper deployment of both node-based and serverless ElastiCache for Valkey instances.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
