### PR TITLE
Add Valkey FTS benchmark scripts and dataset

### DIFF
--- a/blogs/elasticache-valkey/fts-benchmark/README.md
+++ b/blogs/elasticache-valkey/fts-benchmark/README.md
@@ -1,0 +1,113 @@
+# Valkey Full-Text Search & Vector Search — Benchmark Dataset & Scripts
+
+This repository contains the dataset and scripts used in the **Valkey FTS on Amazon ElastiCache** blog post.
+
+## Dataset
+
+The dataset is based on the [Amazon ESCI (Shopping Queries)](https://github.com/amazon-science/esci-data) product catalog — **137,042 products** with rich metadata.
+
+Download from [Releases](https://github.com/ebalan/valkey-FTS-blog/releases/tag/v1.0):
+
+| File | Size | Description |
+|------|------|-------------|
+| `products_esci_vec.jsonl.gz` | 24 MB | 137K products — text, tags, numerics (no vectors) |
+| `products_esci_vec_64d.jsonl.gz` | 110 MB | 137K products — all fields + 64-dim vector embeddings |
+
+### Fields per record
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | TEXT | Product title (full-text indexed) |
+| `description` | TEXT | Product description |
+| `brand` | TAG | Brand name |
+| `color` | TAG | Product color |
+| `price` | NUMERIC | Price in cents |
+| `rating` | NUMERIC | Rating (0-5) |
+| `stock` | NUMERIC | Stock level (0-999) |
+| `embedding` | VECTOR | 64-dim FLOAT32 (BAAI/bge-small-en-v1.5, truncated) — only in `_64d` file |
+
+## Scripts
+
+### `load_products.py` — Load text/tag/numeric data (fast)
+
+Bulk-loads the non-vector dataset using `valkey-cli --pipe` (RESP protocol streaming). Loads 137K products in ~2 minutes.
+
+```bash
+# Requirements: Python 3.8+, valkey-cli in PATH
+python3 load_products.py --host your-cluster.cache.amazonaws.com
+```
+
+**What it does:**
+1. Downloads the dataset from GitHub (24 MB)
+2. Creates `products_index` with TEXT, TAG, and NUMERIC fields
+3. Streams HSET commands via `valkey-cli --pipe`
+
+### `load_vectors.py` — Load with vector embeddings (fast)
+
+Bulk-loads the full dataset including 64-dim vector embeddings using `valkey-cli --pipe` with binary RESP encoding.
+
+```bash
+# Requirements: Python 3.8+, valkey-cli in PATH
+# Place products_esci_vec_64d.jsonl.gz in same directory
+python3 load_vectors.py your-cluster.cache.amazonaws.com
+```
+
+**What it does:**
+1. Creates `products_vec_index` with TEXT, TAG, NUMERIC, and VECTOR FLAT (COSINE, 64-dim) fields
+2. Encodes each embedding as a raw FLOAT32 binary blob (256 bytes per vector)
+3. Streams everything via `valkey-cli --pipe`
+
+### `load_products_blog.py` — Simple Python client loader (blog snippet)
+
+A readable, blog-friendly version using the `valkey` Python client directly. Slower (~17 docs/sec) but simpler code.
+
+```bash
+pip install valkey
+python3 load_products_blog.py
+```
+
+**What it does:**
+1. Downloads the 110 MB vector dataset from GitHub Releases
+2. Creates the index using the `valkey-py` search API
+3. Loads products using pipelined HSET with `struct.pack` for vector encoding
+
+### `query_examples.py` — All query types demonstrated
+
+Shows every search pattern: full-text, prefix, fuzzy, tag, numeric, combined, KNN vector, and hybrid (text + vector).
+
+```bash
+pip install valkey
+python3 query_examples.py --host your-cluster.cache.amazonaws.com
+```
+
+## Performance Note
+
+| Method | Speed | Use case |
+|--------|-------|----------|
+| `valkey-cli --pipe` | ~1,100 docs/sec | Production bulk loads |
+| Python client pipeline | ~17 docs/sec | Simple scripts, small datasets |
+
+The Python client is slow because Valkey blocks on TEXT field tokenization during each pipeline batch. For large datasets, always use the RESP protocol pipe method.
+
+## Index Schemas
+
+### `products_index` (non-vector)
+```
+FT.CREATE products_index ON HASH PREFIX 1 product:
+  SCHEMA title TEXT description TEXT
+  brand TAG SEPARATOR , color TAG SEPARATOR ,
+  price NUMERIC rating NUMERIC stock NUMERIC
+```
+
+### `products_vec_index` (with vectors)
+```
+FT.CREATE products_vec_index ON HASH PREFIX 1 pv:
+  SCHEMA title TEXT description TEXT
+  brand TAG SEPARATOR , color TAG SEPARATOR ,
+  price NUMERIC rating NUMERIC stock NUMERIC
+  embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 64 DISTANCE_METRIC COSINE
+```
+
+## License
+
+Dataset derived from [Amazon ESCI](https://github.com/amazon-science/esci-data) under Apache 2.0.

--- a/blogs/elasticache-valkey/fts-benchmark/load_products.py
+++ b/blogs/elasticache-valkey/fts-benchmark/load_products.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Load the Amazon ESCI product dataset into Valkey with a full-text search index.
+
+Downloads the dataset from GitHub, creates a search index with TEXT, TAG,
+and NUMERIC fields, and bulk-loads 137K products using valkey-cli --pipe.
+
+Usage:
+    python3 load_products.py --host <valkey-host>
+
+Requirements:
+    - Python 3.8+
+    - valkey-cli in PATH
+"""
+import argparse
+import gzip
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+
+DATASET_URL = "https://github.com/ebalan/valkey-FTS-blog/raw/main/products_esci_vec.jsonl.gz"
+DATASET_FILE = "products_esci_vec.jsonl.gz"
+
+INDEX_NAME = "products_index"
+PREFIX = "product:"
+FIELDS = ("title", "description", "brand", "color", "rating", "price", "stock")
+
+
+def download_dataset(url=DATASET_URL, dest=DATASET_FILE):
+    """Download the gzipped dataset from GitHub."""
+    if os.path.exists(dest):
+        print(f"Dataset already exists: {dest}")
+        return dest
+    print(f"Downloading dataset from {url} ...")
+    start = time.time()
+    urllib.request.urlretrieve(url, dest)
+    mb = os.path.getsize(dest) / 1024 / 1024
+    print(f"Downloaded {mb:.1f} MB in {time.time() - start:.1f}s")
+    return dest
+
+
+def redis_proto(*args):
+    """Encode a single command in RESP (Redis Serialization Protocol)."""
+    tokens = [f"*{len(args)}\r\n"]
+    for a in args:
+        s = str(a).encode()
+        tokens.append(f"${len(s)}\r\n")
+        tokens.append(s.decode() + "\r\n")
+    return "".join(tokens)
+
+
+def generate_protocol(dataset_path):
+    """Yield RESP-encoded commands: DROP + CREATE index, then HSET per product."""
+
+    # 1. Drop any existing index (will error-reply if absent — that's fine)
+    yield redis_proto("FT.DROPINDEX", INDEX_NAME)
+
+    # 2. Create the search index
+    yield redis_proto(
+        "FT.CREATE", INDEX_NAME,
+        "ON", "HASH", "PREFIX", "1", PREFIX,
+        "SCHEMA",
+        "title",       "TEXT",
+        "description", "TEXT",
+        "brand",       "TAG", "SEPARATOR", ",",
+        "color",       "TAG", "SEPARATOR", ",",
+        "price",       "NUMERIC",
+        "rating",      "NUMERIC",
+        "stock",       "NUMERIC",
+    )
+
+    # 3. HSET each product
+    opener = gzip.open if dataset_path.endswith(".gz") else open
+    count = 0
+    with opener(dataset_path, "rt", encoding="utf-8") as fh:
+        for line in fh:
+            rec = json.loads(line)
+            pid = rec.get("key", "").split(":")[-1] or str(count)
+            args = ["HSET", f"{PREFIX}{pid}"]
+            for field in FIELDS:
+                if field in rec:
+                    args.extend([field, rec[field]])
+            if len(args) > 2:
+                yield redis_proto(*args)
+                count += 1
+                if count % 25_000 == 0:
+                    print(f"  Generated {count:,} commands ...", file=sys.stderr)
+
+    print(f"  Total: {count:,} HSET commands", file=sys.stderr)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Bulk-load products into Valkey")
+    ap.add_argument("--host", required=True, help="Valkey hostname")
+    ap.add_argument("--port", type=int, default=6379)
+    ap.add_argument("--dataset", default=DATASET_FILE, help="Local dataset path")
+    ap.add_argument("--skip-download", action="store_true")
+    args = ap.parse_args()
+
+    # Step 1 — download
+    if not args.skip_download:
+        dataset = download_dataset(dest=args.dataset)
+    else:
+        dataset = args.dataset
+        if not os.path.exists(dataset):
+            sys.exit(f"Dataset not found: {dataset}")
+
+    # Step 2 — stream RESP into valkey-cli --pipe
+    print(f"Loading into {args.host}:{args.port} ...")
+    start = time.time()
+
+    pipe_cmd = ["valkey-cli", "-h", args.host, "-p", str(args.port), "--pipe"]
+    proc = subprocess.Popen(pipe_cmd, stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    for chunk in generate_protocol(dataset):
+        proc.stdin.write(chunk.encode())
+    proc.stdin.close()
+
+    output = proc.communicate()[0].decode()
+    elapsed = time.time() - start
+
+    print(output)
+    print(f"\nCompleted in {elapsed:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/blogs/elasticache-valkey/fts-benchmark/load_products_blog.py
+++ b/blogs/elasticache-valkey/fts-benchmark/load_products_blog.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Load 137K products with vector embeddings into Valkey."""
+import gzip
+import json
+import struct
+import urllib.request
+import valkey
+from valkey.commands.search.field import TextField, TagField, NumericField, VectorField
+from valkey.commands.search.indexDefinition import IndexDefinition, IndexType
+
+# <Input required>: Insert your ElastiCache cluster's endpoint
+VALKEY_HOST = "mycluster.cnxa6h.clustercfg.use1.cache.amazonaws.com"
+
+client = valkey.Valkey(host=VALKEY_HOST, port=6379, decode_responses=False)
+
+# Create the search index with text, tag, numeric, and vector fields
+try:
+    client.execute_command("FT.DROPINDEX", "products_vec_index")
+except:
+    pass
+
+client.ft("products_vec_index").create_index(
+    fields=[
+        TextField("title"),
+        TextField("description"),
+        TagField("brand", separator=","),
+        TagField("color", separator=","),
+        NumericField("price"),
+        NumericField("rating"),
+        NumericField("stock"),
+        VectorField("embedding", "FLAT", {
+            "TYPE": "FLOAT32",
+            "DIM": 64,
+            "DISTANCE_METRIC": "COSINE",
+        }),
+    ],
+    definition=IndexDefinition(prefix=["pv:"], index_type=IndexType.HASH),
+)
+
+# Download and load the product dataset with 64-dim embeddings
+DATASET_URL = "https://github.com/ebalan/valkey-FTS-blog/releases/download/v1.0/products_esci_vec_64d.jsonl.gz"
+print("Downloading dataset...")
+urllib.request.urlretrieve(DATASET_URL, "products.jsonl.gz")
+
+print("Loading products...")
+count = 0
+pipe = client.pipeline(transaction=False)
+
+with gzip.open("products.jsonl.gz", "rt") as f:
+    for line in f:
+        rec = json.loads(line)
+        key = f"pv:{rec['key'].split(':')[-1]}"
+
+        # Convert embedding list to binary FLOAT32 blob
+        embedding = struct.pack(f"{len(rec['embedding'])}f", *rec["embedding"])
+
+        pipe.hset(key, mapping={
+            "title": rec.get("title", ""),
+            "description": rec.get("description", ""),
+            "brand": rec.get("brand", ""),
+            "color": rec.get("color", ""),
+            "price": rec.get("price", 0),
+            "rating": rec.get("rating", 0),
+            "stock": rec.get("stock", 0),
+            "embedding": embedding,
+        })
+
+        count += 1
+        if count % 1000 == 0:
+            pipe.execute()
+            pipe = client.pipeline(transaction=False)
+            print(f"  {count:,} products loaded...")
+
+    pipe.execute()
+
+print(f"Done! Loaded {count:,} products into products_vec_index")

--- a/blogs/elasticache-valkey/fts-benchmark/load_vectors.py
+++ b/blogs/elasticache-valkey/fts-benchmark/load_vectors.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Load products with 64-dim vectors into Valkey using valkey-cli --pipe."""
+import gzip
+import json
+import os
+import struct
+import sys
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+INPUT = os.path.join(SCRIPT_DIR, "products_esci_vec_64d.jsonl.gz")
+HOST = sys.argv[1] if len(sys.argv) > 1 else "sivasams-cluster.lajljv.ng.0001.euw1devo.cache.amazonaws.com"
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 6379
+INDEX = "products_vec_index"
+PREFIX = "pv:"
+DIM = 64
+
+def resp(*args):
+    """Encode command as RESP protocol (binary-safe)."""
+    parts = []
+    parts.append(f"*{len(args)}\r\n".encode())
+    for a in args:
+        if isinstance(a, bytes):
+            parts.append(f"${len(a)}\r\n".encode())
+            parts.append(a)
+            parts.append(b"\r\n")
+        else:
+            s = str(a).encode()
+            parts.append(f"${len(s)}\r\n".encode())
+            parts.append(s)
+            parts.append(b"\r\n")
+    return b"".join(parts)
+
+import subprocess
+
+# Drop existing index
+print(f"Dropping index {INDEX} (if exists)...", flush=True)
+subprocess.run(["valkey-cli", "-h", HOST, "-p", str(PORT), "FT.DROPINDEX", INDEX], capture_output=True)
+
+# Create index with VECTOR field
+print(f"Creating index {INDEX}...", flush=True)
+create_cmd = [
+    "valkey-cli", "-h", HOST, "-p", str(PORT),
+    "FT.CREATE", INDEX,
+    "ON", "HASH", "PREFIX", "1", PREFIX,
+    "SCHEMA",
+    "title", "TEXT",
+    "description", "TEXT",
+    "brand", "TAG", "SEPARATOR", ",",
+    "color", "TAG", "SEPARATOR", ",",
+    "price", "NUMERIC",
+    "rating", "NUMERIC",
+    "stock", "NUMERIC",
+    "embedding", "VECTOR", "FLAT", "6",
+    "TYPE", "FLOAT32",
+    "DIM", str(DIM),
+    "DISTANCE_METRIC", "COSINE",
+]
+result = subprocess.run(create_cmd, capture_output=True, text=True)
+print(f"  Result: {result.stdout.strip()}", flush=True)
+if result.returncode != 0:
+    print(f"  Error: {result.stderr.strip()}", flush=True)
+
+# Bulk load via pipe
+print(f"Loading data from {INPUT}...", flush=True)
+start = time.time()
+
+pipe_cmd = ["valkey-cli", "-h", HOST, "-p", str(PORT), "--pipe"]
+proc = subprocess.Popen(pipe_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+count = 0
+with gzip.open(INPUT, "rt", encoding="utf-8") as f:
+    for line in f:
+        rec = json.loads(line)
+        pid = rec.get("key", "").split(":")[-1] or str(count)
+        
+        # Build HSET args
+        args = ["HSET", f"{PREFIX}{pid}"]
+        for field in ("title", "description", "brand", "color", "price", "rating", "stock"):
+            if field in rec:
+                args.append(field)
+                args.append(str(rec[field]))
+        
+        # Add vector as binary blob (FLOAT32)
+        if "embedding" in rec:
+            vec = rec["embedding"]
+            blob = struct.pack(f"{len(vec)}f", *vec)
+            args.append("embedding")
+            args.append(blob)
+        
+        try:
+            proc.stdin.write(resp(*args))
+        except BrokenPipeError:
+            print(f"Pipe broke at record {count}", flush=True)
+            break
+        count += 1
+        if count % 25000 == 0:
+            proc.stdin.flush()
+            print(f"  Sent {count:,} ...", flush=True)
+
+try:
+    proc.stdin.close()
+except:
+    pass
+output = proc.communicate()[0].decode()
+elapsed = time.time() - start
+
+print(output, flush=True)
+print(f"\nLoaded {count:,} products with vectors in {elapsed:.1f}s", flush=True)

--- a/blogs/elasticache-valkey/fts-benchmark/load_vectors.py
+++ b/blogs/elasticache-valkey/fts-benchmark/load_vectors.py
@@ -9,7 +9,7 @@ import time
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 INPUT = os.path.join(SCRIPT_DIR, "products_esci_vec_64d.jsonl.gz")
-HOST = sys.argv[1] if len(sys.argv) > 1 else "sivasams-cluster.lajljv.ng.0001.euw1devo.cache.amazonaws.com"
+HOST = sys.argv[1] if len(sys.argv) > 1 else "your-cluster.cache.amazonaws.com"
 PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 6379
 INDEX = "products_vec_index"
 PREFIX = "pv:"

--- a/blogs/elasticache-valkey/fts-benchmark/query_examples.py
+++ b/blogs/elasticache-valkey/fts-benchmark/query_examples.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Query examples for Valkey Full-Text Search + Vector Search.
+
+Demonstrates:
+1. Text search (full-text)
+2. Prefix search (autocomplete-style)
+3. Fuzzy search (typo tolerance)
+4. Tag filter
+5. Numeric range filter
+6. Combined text + numeric filter
+7. KNN vector search (pure)
+8. Hybrid search (text filter + vector KNN)
+
+Usage:
+    pip install valkey
+    python3 query_examples.py --host <valkey-host>
+"""
+import argparse
+import struct
+import valkey
+from valkey.commands.search.query import Query
+
+def main():
+    ap = argparse.ArgumentParser(description="Valkey FTS query examples")
+    ap.add_argument("--host", required=True, help="Valkey host")
+    ap.add_argument("--port", type=int, default=6379)
+    args = ap.parse_args()
+
+    # Text-mode client for standard queries
+    client = valkey.Valkey(host=args.host, port=args.port, decode_responses=True)
+    # Binary-mode client for vector queries
+    client_bin = valkey.Valkey(host=args.host, port=args.port, decode_responses=False)
+
+    INDEX = "products_vec_index"
+    print("=" * 70)
+
+    # ─── 1. Full-Text Search ───────────────────────────────────────────────
+    print("\n1. FULL-TEXT SEARCH: 'wireless headphones'")
+    print("-" * 50)
+    results = client.ft(INDEX).search(
+        Query("wireless headphones")
+        .return_fields("title", "brand", "price")
+        .paging(0, 5)
+    )
+    print(f"   Total matches: {results.total}")
+    for doc in results.docs:
+        print(f"   {doc.id}: {doc.title[:60]} | {doc.brand} | ${doc.price}")
+
+    # ─── 2. Prefix Search ─────────────────────────────────────────────────
+    print("\n2. PREFIX SEARCH: 'wire*' (autocomplete)")
+    print("-" * 50)
+    results = client.ft(INDEX).search(
+        Query("wire*")
+        .return_fields("title", "brand")
+        .paging(0, 5)
+    )
+    print(f"   Total matches: {results.total}")
+    for doc in results.docs:
+        print(f"   {doc.id}: {doc.title[:60]} | {doc.brand}")
+
+    # ─── 3. Fuzzy Search ──────────────────────────────────────────────────
+    print("\n3. FUZZY SEARCH: '%%headphnes%%' (typo tolerant)")
+    print("-" * 50)
+    results = client.ft(INDEX).search(
+        Query("%%headphnes%%")
+        .return_fields("title", "brand")
+        .paging(0, 5)
+    )
+    print(f"   Total matches: {results.total}")
+    for doc in results.docs:
+        print(f"   {doc.id}: {doc.title[:60]} | {doc.brand}")
+
+    # ─── 4. Tag Filter ────────────────────────────────────────────────────
+    print("\n4. TAG FILTER: @brand:{Sony}")
+    print("-" * 50)
+    results = client.ft(INDEX).search(
+        Query("@brand:{Sony}")
+        .return_fields("title", "brand", "price")
+        .paging(0, 5)
+    )
+    print(f"   Total matches: {results.total}")
+    for doc in results.docs:
+        print(f"   {doc.id}: {doc.title[:60]} | ${doc.price}")
+
+    # ─── 5. Numeric Range ─────────────────────────────────────────────────
+    print("\n5. NUMERIC RANGE: @price:[100 500]")
+    print("-" * 50)
+    results = client.ft(INDEX).search(
+        Query("@price:[100 500]")
+        .return_fields("title", "price")
+        .paging(0, 5)
+    )
+    print(f"   Total matches: {results.total}")
+    for doc in results.docs:
+        print(f"   {doc.id}: {doc.title[:60]} | ${doc.price}")
+
+    # ─── 6. Combined: Text + Numeric ──────────────────────────────────────
+    print("\n6. COMBINED: 'headphones @price:[50 200]'")
+    print("-" * 50)
+    results = client.ft(INDEX).search(
+        Query("headphones @price:[50 200]")
+        .return_fields("title", "brand", "price")
+        .paging(0, 5)
+    )
+    print(f"   Total matches: {results.total}")
+    for doc in results.docs:
+        print(f"   {doc.id}: {doc.title[:60]} | {doc.brand} | ${doc.price}")
+
+    # ─── 7. KNN Vector Search (pure) ──────────────────────────────────────
+    print("\n7. KNN VECTOR SEARCH: Top 5 similar to 'American Audio HP-550'")
+    print("-" * 50)
+    # Get embedding from a known product
+    product_embedding = client_bin.hget("pv:B001O4JX5O", "embedding")
+    if product_embedding:
+        results = client_bin.execute_command(
+            "FT.SEARCH", INDEX,
+            "*=>[KNN 5 @embedding $vec AS score]",
+            "PARAMS", "2", "vec", product_embedding,
+            "RETURN", "3", "title", "score", "brand",
+            "SORTBY", "score",
+            "DIALECT", "2",
+        )
+        print(f"   Top 5 nearest neighbors:")
+        for i in range(1, len(results), 2):
+            doc_id = results[i].decode()
+            fields = results[i + 1]
+            fdict = {}
+            for j in range(0, len(fields), 2):
+                fdict[fields[j].decode()] = fields[j + 1].decode()
+            print(f"   {doc_id}: score={fdict.get('score','?')[:8]} | "
+                  f"{fdict.get('title','')[:50]} | {fdict.get('brand','')}")
+    else:
+        print("   (product pv:B001O4JX5O not found — skip)")
+
+    # ─── 8. Hybrid Search: Text + Vector KNN ──────────────────────────────
+    print("\n8. HYBRID SEARCH: text 'headphones' + KNN vector ranking")
+    print("-" * 50)
+    if product_embedding:
+        results = client_bin.execute_command(
+            "FT.SEARCH", INDEX,
+            "@title:headphones =>[KNN 5 @embedding $vec AS score]",
+            "PARAMS", "2", "vec", product_embedding,
+            "RETURN", "3", "title", "score", "brand",
+            "DIALECT", "2",
+        )
+        print(f"   Pre-filter: @title:headphones")
+        print(f"   Then rank by vector similarity to 'American Audio HP-550':\n")
+        for i in range(1, len(results), 2):
+            doc_id = results[i].decode()
+            fields = results[i + 1]
+            fdict = {}
+            for j in range(0, len(fields), 2):
+                fdict[fields[j].decode()] = fields[j + 1].decode()
+            print(f"   {doc_id}: score={fdict.get('score','?')[:8]} | "
+                  f"{fdict.get('title','')[:50]} | {fdict.get('brand','')}")
+    else:
+        print("   (product pv:B001O4JX5O not found — skip)")
+
+    print("\n" + "=" * 70)
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds scripts and documentation for benchmarking Valkey Full-Text Search (FTS) and Vector Search on Amazon ElastiCache.

### New files in `blogs/elasticache-valkey/fts-benchmark/`

| File | Description |
|------|-------------|
| `README.md` | Dataset docs, usage instructions, index schemas, performance notes |
| `load_products.py` | Fast bulk loader using `valkey-cli --pipe` (137K products, TEXT/TAG/NUMERIC) |
| `load_vectors.py` | Bulk loader with 64-dim vector embeddings via `valkey-cli --pipe` |
| `load_products_blog.py` | Simple Python client loader (blog-friendly snippet) |
| `query_examples.py` | All query types: full-text, prefix, fuzzy, tag, numeric, KNN vector, hybrid |

### Dataset

137,042 Amazon ESCI products with rich metadata. Available as GitHub Release assets at [ebalan/valkey-FTS-blog v1.0](https://github.com/ebalan/valkey-FTS-blog/releases/tag/v1.0).

### Requirements

- Python 3.8+
- `valkey-cli` in PATH (for fast loaders)
- `pip install valkey` (for blog loader and query examples)